### PR TITLE
Change docker tag

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: ghcr.io/cisco-open/cluster-registry-controller
-          tags: type=semver,pattern={{version}}
+          tags: type=semver,pattern={{raw}}
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Instead of `0.1.7` we should have `v0.1.7` as the Docker image tag with this change.

Source: https://github.com/docker/metadata-action#typesemver
