### PR TITLE
Add helm publish with Github Actions

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -1,0 +1,31 @@
+name: Helm
+
+on:
+  push:
+    tags:
+      - "deploy/charts/v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.8.1
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.4.0
+        with:
+          charts_dir: deploy/charts
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/deploy/charts/cluster-registry/Chart.yaml
+++ b/deploy/charts/cluster-registry/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 name: cluster-registry
-description: Cluster registry for K8s
-home: https://banzaicloud.com
+description: Cluster registry controller for K8s
+home: https://eti.cisco.com/
 
 maintainers:
-- email: info@banzaicloud.com
-  name: Banzai Cloud
+- email: ciscoeti@cisco.com
+  name: Cisco
 sources:
-- https://github.com/banzaicloud/backyards
+- https://github.com/cisco-open/cluster-registry-controller
 
 version: 0.1.6
 appVersion: v0.1.6

--- a/deploy/charts/cluster-registry/values.yaml
+++ b/deploy/charts/cluster-registry/values.yaml
@@ -21,7 +21,7 @@ podSecurityContext:
 securityContext:
   allowPrivilegeEscalation: false
 image:
-  repository: 033498657557.dkr.ecr.us-east-2.amazonaws.com/banzaicloud/cluster-registry-controller
+  repository: ghcr.io/cisco-open/cluster-registry-controller
   tag: v0.1.6
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets |
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

On tags like `deploy/charts/v[0-9]+.[0-9]+.[0-9]+`, a GH release will be prepared with helm artifacts and `index.yaml`. So creates a self-hosted Helm chart repo.
