### PR TITLE
Fix default podAnnotations

### DIFF
--- a/deploy/charts/cluster-registry/Chart.yaml
+++ b/deploy/charts/cluster-registry/Chart.yaml
@@ -9,5 +9,5 @@ maintainers:
 sources:
   - https://github.com/cisco-open/cluster-registry-controller
 
-version: 0.2.2
-appVersion: v0.2.2
+version: 0.2.3
+appVersion: v0.2.3

--- a/deploy/charts/cluster-registry/values.yaml
+++ b/deploy/charts/cluster-registry/values.yaml
@@ -12,7 +12,7 @@ localCluster:
 istio:
   revision: ""
 
-podAnnotations: []
+podAnnotations: {}
 imagePullSecrets: []
 
 podSecurityContext:
@@ -22,7 +22,7 @@ securityContext:
   allowPrivilegeEscalation: false
 image:
   repository: ghcr.io/cisco-open/cluster-registry-controller
-  tag: v0.2.2
+  tag: v0.2.3
   pullPolicy: IfNotPresent
 
 nodeSelector: {}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Change default value for `podAnnotations` to empty map from empty slice as annotations as key value pairs

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Annotations are key value pairs and not a array of elements.

