### PR TITLE
[Fix] Refactor reader secret method to get CAData from KubeConfig file 

### DIFF
--- a/deploy/charts/cluster-registry/Chart.yaml
+++ b/deploy/charts/cluster-registry/Chart.yaml
@@ -9,5 +9,5 @@ maintainers:
 sources:
   - https://github.com/cisco-open/cluster-registry-controller
 
-version: 0.2.4
-appVersion: v0.2.4
+version: 0.2.5
+appVersion: v0.2.5

--- a/deploy/charts/cluster-registry/README.md
+++ b/deploy/charts/cluster-registry/README.md
@@ -41,7 +41,7 @@ Parameter | Description | Default
 `podSecurityContext` | Operator deployment pod security context (YAML) | runAsUser: `65534`, runAsGroup: `65534`
 `securityContext` | Operator deployment security context (YAML) | allowPrivilegeEscalation: `false`
 `image.repository` | Operator container image repository | `ghcr.io/cisco-open/cluster-registry-controller`
-`image.tag` | Operator container image tag | `v0.2.4`
+`image.tag` | Operator container image tag | `v0.2.5`
 `image.pullPolicy` | Operator container image pull policy | `IfNotPresent`
 `nodeselector` | Operator deployment node selector (YAML) | `{}`
 `affinity` | Operator deployment affinity (YAML) | `{}`

--- a/deploy/charts/cluster-registry/values.yaml
+++ b/deploy/charts/cluster-registry/values.yaml
@@ -22,7 +22,7 @@ securityContext:
   allowPrivilegeEscalation: false
 image:
   repository: ghcr.io/cisco-open/cluster-registry-controller
-  tag: v0.2.4
+  tag: v0.2.5
   pullPolicy: IfNotPresent
 
 nodeSelector: {}

--- a/pkg/util/cluster_secret.go
+++ b/pkg/util/cluster_secret.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"bytes"
 	"context"
 	"net"
 
@@ -24,9 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterregistryv1alpha1 "github.com/cisco-open/cluster-registry-controller/api/v1alpha1"
@@ -65,7 +64,6 @@ func GetReaderSecretForCluster(ctx context.Context, kubeClient client.Client, ku
 		return nil, errors.WithStackIf(err)
 	}
 
-	clientSet, _ := kubernetes.NewForConfig(ctrl.GetConfigOrDie())
 	// After K8s v1.24, Secret objects containing ServiceAccount tokens are no longer auto-generated, so we will have to manually create Secret in order to get the token.
 	// Reference: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#no-really-you-must-read-this-before-you-upgrade
 	var secretObj *corev1.Secret
@@ -75,10 +73,15 @@ func GetReaderSecretForCluster(ctx context.Context, kubeClient client.Client, ku
 		readerSecretName = sa.Secrets[0].Name
 	}
 
-	secretObj, err = clientSet.CoreV1().Secrets(saRef.Namespace).Get(ctx, readerSecretName, metav1.GetOptions{})
+	secretObjRef := types.NamespacedName{
+		Namespace: saRef.Namespace,
+		Name: readerSecretName,
+	}
+
+	err = kubeClient.Get(ctx, secretObjRef ,secretObj)
 	if err != nil &&
 		k8sErrors.IsNotFound(err) {
-		readerSATokenSecret := corev1.Secret{
+		readerSATokenSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      readerSecretName,
 				Namespace: saRef.Namespace,
@@ -89,7 +92,7 @@ func GetReaderSecretForCluster(ctx context.Context, kubeClient client.Client, ku
 			Type: "kubernetes.io/service-account-token",
 		}
 
-		secretObj, err = clientSet.CoreV1().Secrets(saRef.Namespace).Create(ctx, &readerSATokenSecret, metav1.CreateOptions{})
+		err = kubeClient.Create(ctx, readerSATokenSecret)
 		if err != nil {
 			return nil, errors.WrapIfWithDetails(err, "creating kubernetes secret failed", "namespace", saRef.Namespace, "secret", readerSecretName)
 		}
@@ -105,6 +108,10 @@ func GetReaderSecretForCluster(ctx context.Context, kubeClient client.Client, ku
 	// fetch CA certificate and token from secret associated with reader SA
 	saToken := string(secretObj.Data["token"])
 	caData := secretObj.Data["ca.crt"]
+
+	if !bytes.Contains(caData, kubeConfig.CAData) {
+		caData = append(append(caData, []byte("\n")...), kubeConfig.CAData...)
+	}
 
 	// add overrides specified in the cluster resource without network specified
 	endpoint := GetEndpointForClusterByNetwork(cluster, "")

--- a/pkg/util/cluster_secret.go
+++ b/pkg/util/cluster_secret.go
@@ -66,7 +66,7 @@ func GetReaderSecretForCluster(ctx context.Context, kubeClient client.Client, ku
 
 	// After K8s v1.24, Secret objects containing ServiceAccount tokens are no longer auto-generated, so we will have to manually create Secret in order to get the token.
 	// Reference: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#no-really-you-must-read-this-before-you-upgrade
-	var secretObj *corev1.Secret
+	secretObj := &corev1.Secret{}
 
 	readerSecretName := saRef.Name + "-token"
 	if len(sa.Secrets) != 0 {

--- a/pkg/util/cluster_secret.go
+++ b/pkg/util/cluster_secret.go
@@ -75,10 +75,10 @@ func GetReaderSecretForCluster(ctx context.Context, kubeClient client.Client, ku
 
 	secretObjRef := types.NamespacedName{
 		Namespace: saRef.Namespace,
-		Name: readerSecretName,
+		Name:      readerSecretName,
 	}
 
-	err = kubeClient.Get(ctx, secretObjRef ,secretObj)
+	err = kubeClient.Get(ctx, secretObjRef, secretObj)
 	if err != nil &&
 		k8sErrors.IsNotFound(err) {
 		readerSATokenSecret := &corev1.Secret{


### PR DESCRIPTION
### Description
Adding these lines back as there will be cases where `kubeConfig.CAData` is not empty
```
if !bytes.Contains(caData, kubeConfig.CAData) {
		caData = append(append(caData, []byte("\n")...), kubeConfig.CAData...)
	}
```
