### PR TITLE
Add readiness probe to check webhook cert ready

### DIFF
--- a/cmd/manager/config.go
+++ b/cmd/manager/config.go
@@ -76,6 +76,7 @@ func initConfiguration(v *viper.Viper, p *flag.FlagSet) {
 	v.AutomaticEnv()
 
 	p.String("metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	p.String("health-addr", ":8090", "The address the health endpoint binds to.")
 	p.Bool("devel-mode", false, "Set development mode (mainly for logging).")
 	p.Bool("version", false, "Show version information")
 	p.Bool("dump-config", false, "Dump configuration to the console")

--- a/deploy/charts/cluster-registry/templates/deployment.yaml
+++ b/deploy/charts/cluster-registry/templates/deployment.yaml
@@ -48,6 +48,9 @@ spec:
             - name: metrics
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+            - name: health
+              containerPort: {{ .Values.health.port }}
+              protocol: TCP
           {{- if and (.Values.webhooks.clusterValidator.enabled) (.Values.webhooks.clusterValidator.port) }}
             - containerPort: {{ .Values.webhooks.clusterValidator.port }}
               name: http-cl-val-wh
@@ -59,8 +62,8 @@ spec:
               port: metrics
           readinessProbe:
             httpGet:
-              path: /metrics
-              port: metrics
+              path: /readyz
+              port: health
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:

--- a/deploy/charts/cluster-registry/values.yaml
+++ b/deploy/charts/cluster-registry/values.yaml
@@ -40,6 +40,9 @@ service:
   type: ClusterIP
   port: 8080
 
+health:
+  port: 8090
+
 serviceAccount:
   annotations: {}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ package config
 
 type Configuration struct {
 	MetricsAddr                string            `mapstructure:"metrics-addr" json:"metricsAddr,omitempty"`
+	HealthAddr                 string            `mapstructure:"health-addr" json:"HealthAddr,omitempty"`
 	LeaderElection             LeaderElection    `mapstructure:"leader-election" json:"leaderElection,omitempty"`
 	Logging                    Logging           `mapstructure:"log" json:"logging,omitempty"`
 	ClusterController          ClusterController `mapstructure:"clusterController" json:"clusterController,omitempty"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,7 +16,7 @@ package config
 
 type Configuration struct {
 	MetricsAddr                string            `mapstructure:"metrics-addr" json:"metricsAddr,omitempty"`
-	HealthAddr                 string            `mapstructure:"health-addr" json:"HealthAddr,omitempty"`
+	HealthAddr                 string            `mapstructure:"health-addr" json:"healthAddr,omitempty"`
 	LeaderElection             LeaderElection    `mapstructure:"leader-election" json:"leaderElection,omitempty"`
 	Logging                    Logging           `mapstructure:"log" json:"logging,omitempty"`
 	ClusterController          ClusterController `mapstructure:"clusterController" json:"clusterController,omitempty"`

--- a/pkg/cert/webhook_certifier.go
+++ b/pkg/cert/webhook_certifier.go
@@ -19,8 +19,9 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	"emperror.dev/errors"
 	"github.com/go-logr/logr"
@@ -411,7 +412,7 @@ func (certifier *WebhookCertifier) updateCertificate() error {
 func (certifier *WebhookCertifier) WebhookCertBundleReadyzChecker() healthz.Checker {
 	return func(req *http.Request) error {
 		if !certifier.webhookCertBundleReadyz {
-			return fmt.Errorf("webhook cert bundle is not ready")
+			return errors.New("webhook cert bundle is not ready yet")
 		}
 
 		return nil

--- a/pkg/cert/webhook_certifier.go
+++ b/pkg/cert/webhook_certifier.go
@@ -17,7 +17,9 @@ package cert
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"strings"
 
 	"emperror.dev/errors"
@@ -61,6 +63,9 @@ type WebhookCertifier struct {
 
 	// triggers is the channel to notify the certificate renewer on changes.
 	triggers chan struct{}
+
+	// webhookCertBundleReadyz is used to check readiness of cluster-registry
+	webhookCertBundleReadyz bool
 }
 
 // NewWebhookCertifier returns an object which can manage the generation and
@@ -71,17 +76,19 @@ func NewWebhookCertifier(
 	webhookNamespace string,
 	webhookManager manager.Manager,
 	certificateRenewer *Renewer,
+	webhookCertBundleReadyz bool,
 ) *WebhookCertifier {
 	return &WebhookCertifier{
 		logger: logger.WithValues("key", client.ObjectKey{
 			Namespace: webhookNamespace,
 			Name:      webhookName,
 		}),
-		webhookName:        webhookName,
-		webhookNamespace:   webhookNamespace,
-		webhookManager:     webhookManager,
-		triggers:           make(chan struct{}),
-		certificateRenewer: certificateRenewer,
+		webhookName:             webhookName,
+		webhookNamespace:        webhookNamespace,
+		webhookManager:          webhookManager,
+		triggers:                make(chan struct{}),
+		certificateRenewer:      certificateRenewer,
+		webhookCertBundleReadyz: webhookCertBundleReadyz,
 	}
 }
 
@@ -122,6 +129,7 @@ func (certifier *WebhookCertifier) Start(ctx context.Context) error {
 			if err != nil {
 				return errors.Wrap(err, "updating webhook certificate failed")
 			}
+			certifier.webhookCertBundleReadyz = true
 		}
 
 		return nil
@@ -398,4 +406,14 @@ func (certifier *WebhookCertifier) updateCertificate() error {
 	logger.Info("webhook configuration certificate updated successfully")
 
 	return nil
+}
+
+func (certifier *WebhookCertifier) WebhookCertBundleReadyzChecker() healthz.Checker {
+	return func(req *http.Request) error {
+		if !certifier.webhookCertBundleReadyz {
+			return fmt.Errorf("webhook cert bundle is not ready")
+		}
+
+		return nil
+	}
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | yes (`/readyz` as readiness probe)
| API breaks?     | yes (`/metrics` as readiness probe)
| Deprecations?   | yes (`/metrics` as readiness probe)
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Add readiness probe to mark cluster-registry as "ready" only after webhook configuration certificate is updated successfully

### Why?
cluster-registry generates self signed certificate to inject into webhook which take approx ~30 sec after deploy.

If we are running an automation script that waits for cluster-registrty to be ready then `/metrics` end point marks container as ready even before caBundle in injected into ValidatingWebhookConfig.

As a result, the automation script would fail with 
```
x509: certificate is not valid for any names, but wanted to match cluster-registry-controller.cluster-registry.svc
```
so we need to wait until the webhook is ready, then mark cluster-registry as "ready"

### Additional context
This PR changes the readiness probe from `/metrics` to `/readyz` which would potentially break API that depends on readiness probe

### Checklist
- [x] Implementation tested
- [x] User guide and development docs updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [x] If the PR is not complete but you want to discuss the approach

### Tests
* Webhook enabled (takes ~30 sec to be ready) (webhook ready health checker)
Init "16:34:22" -> Ready "16:35:02" (40 seconds)
```
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2022-12-12T16:34:22Z"
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2022-12-12T16:35:02Z"
    status: "True"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2022-12-12T16:35:02Z"
    status: "True"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2022-12-12T16:34:22Z"
    status: "True"
    type: PodScheduled
  containerStatuses:
  - containerID: docker://7c5063a148ea36dc0d7f4fa8451710ae34f304b1b4e05475e607d7b7bffacf20
    image: nishantapatil3/cluster-registry-controller:latest
    imageID: docker-pullable://nishantapatil3/cluster-registry-controller@sha256:1a672de686f0e0c2419be9194a2bb55cdd1cf0437ff2c72a840f3b70aafb2504
    lastState: {}
    name: manager
    ready: true
    restartCount: 0
    started: true
    state:
      running:
        startedAt: "2022-12-12T16:34:24Z"
```

* Webhook disabled (takes ~5 sec to be ready) (ping health checker)
Init "16:29:06" -> Ready "16:29:10" (4 seconds)
```
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2022-12-12T16:29:06Z"
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2022-12-12T16:29:10Z"
    status: "True"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2022-12-12T16:29:10Z"
    status: "True"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2022-12-12T16:29:06Z"
    status: "True"
    type: PodScheduled
  containerStatuses:
  - containerID: docker://b12445fe5a486db6227e1d9b2b76fb6dcacadff25c1ff96e5a6a62fd70a74c40
    image: nishantapatil3/cluster-registry-controller:latest
    imageID: docker-pullable://nishantapatil3/cluster-registry-controller@sha256:1a672de686f0e0c2419be9194a2bb55cdd1cf0437ff2c72a840f3b70aafb2504
    lastState: {}
    name: manager
    ready: true
    restartCount: 0
    started: true
    state:
      running:
        startedAt: "2022-12-12T16:29:08Z"
```