### PR TITLE
Bump image and chart versions v0.2.6 -> v0.2.7

### DIFF
--- a/deploy/charts/cluster-registry/Chart.yaml
+++ b/deploy/charts/cluster-registry/Chart.yaml
@@ -9,5 +9,5 @@ maintainers:
 sources:
   - https://github.com/cisco-open/cluster-registry-controller
 
-version: 0.2.6
-appVersion: v0.2.6
+version: 0.2.7
+appVersion: v0.2.7

--- a/deploy/charts/cluster-registry/README.md
+++ b/deploy/charts/cluster-registry/README.md
@@ -41,7 +41,7 @@ Parameter | Description | Default
 `podSecurityContext` | Operator deployment pod security context (YAML) | runAsUser: `65534`, runAsGroup: `65534`
 `securityContext` | Operator deployment security context (YAML) | allowPrivilegeEscalation: `false`
 `image.repository` | Operator container image repository | `ghcr.io/cisco-open/cluster-registry-controller`
-`image.tag` | Operator container image tag | `v0.2.6`
+`image.tag` | Operator container image tag | `v0.2.7`
 `image.pullPolicy` | Operator container image pull policy | `IfNotPresent`
 `nodeselector` | Operator deployment node selector (YAML) | `{}`
 `affinity` | Operator deployment affinity (YAML) | `{}`

--- a/deploy/charts/cluster-registry/values.yaml
+++ b/deploy/charts/cluster-registry/values.yaml
@@ -22,7 +22,7 @@ securityContext:
   allowPrivilegeEscalation: false
 image:
   repository: ghcr.io/cisco-open/cluster-registry-controller
-  tag: v0.2.6
+  tag: v0.2.7
   pullPolicy: IfNotPresent
 
 nodeSelector: {}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Bump-up charts and image versions

### Why?
To release next minor version of cluster-registry including the latest code.
