### PR TITLE
Add Support for OpenShift v4.11+

### DIFF
--- a/deploy/charts/cluster-registry/values.yaml
+++ b/deploy/charts/cluster-registry/values.yaml
@@ -16,10 +16,14 @@ podAnnotations: {}
 imagePullSecrets: []
 
 podSecurityContext:
-  runAsUser: 65534
-  runAsGroup: 65534
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
 securityContext:
   allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
 image:
   repository: ghcr.io/cisco-open/cluster-registry-controller
   tag: v0.2.7


### PR DESCRIPTION
### Description
- Update podSecurityContext and securityContext to support deployment in Redhat Openshift 4.11(k8s 1.24+)
- Replace nobody:nobody user to non-root user appuser:1000 and appgroup:1000 so that the cluster-registry helm chart works properly on regular k8s clusters

### Manual tests
RHOS 4.11
```
k get nodes -A
NAME                           STATUS   ROLES          AGE    VERSION
ip-10-0-132-151.ec2.internal   Ready    infra,worker   2d2h   v1.24.6+5658434
ip-10-0-140-77.ec2.internal    Ready    worker         2d3h   v1.24.6+5658434
ip-10-0-158-35.ec2.internal    Ready    master         2d3h   v1.24.6+5658434
ip-10-0-159-227.ec2.internal   Ready    worker         2d3h   v1.24.6+5658434
ip-10-0-159-63.ec2.internal    Ready    worker         2d3h   v1.24.6+5658434
ip-10-0-160-205.ec2.internal   Ready    worker         2d3h   v1.24.6+5658434
ip-10-0-170-223.ec2.internal   Ready    worker         2d3h   v1.24.6+5658434
ip-10-0-180-115.ec2.internal   Ready    infra,worker   2d2h   v1.24.6+5658434
ip-10-0-183-15.ec2.internal    Ready    master         2d3h   v1.24.6+5658434
ip-10-0-187-200.ec2.internal   Ready    worker         2d3h   v1.24.6+5658434
ip-10-0-198-42.ec2.internal    Ready    worker         2d3h   v1.24.6+5658434
ip-10-0-205-221.ec2.internal   Ready    worker         2d3h   v1.24.6+5658434
ip-10-0-215-244.ec2.internal   Ready    infra,worker   2d2h   v1.24.6+5658434
ip-10-0-215-76.ec2.internal    Ready    master         2d3h   v1.24.6+5658434
ip-10-0-222-135.ec2.internal   Ready    worker         2d3h   v1.24.6+5658434

k get pods -n cluster-registry
NAME                                           READY   STATUS    RESTARTS   AGE
cluster-registry-controller-75d988cd56-bvc6v   1/1     Running   0          88m
```

K8s 1.24
```
k get nodes
NAME                                          STATUS   ROLES    AGE     VERSION
gke-smm-test-crc-samuel-pool1-1cb56090-2l9v   Ready    <none>   6m31s   v1.24.8-gke.2000
gke-smm-test-crc-samuel-pool1-1cb56090-khzq   Ready    <none>   6m29s   v1.24.8-gke.2000
gke-smm-test-crc-samuel-pool1-1cb56090-njh6   Ready    <none>   6m27s   v1.24.8-gke.2000

k get pods -n cluster-registry
NAME                                           READY   STATUS    RESTARTS   AGE
cluster-registry-controller-64584cc8d7-gbvb6   1/1     Running   0          53s
```

K8s 1.23
```
k get nodes
NAME                                              STATUS   ROLES    AGE    VERSION
gke-smm-crc-test-samuel-123-pool1-6029f13c-5lmc   Ready    <none>   5m6s   v1.23.14-gke.1800
gke-smm-crc-test-samuel-123-pool1-6029f13c-9w8p   Ready    <none>   5m7s   v1.23.14-gke.1800
gke-smm-crc-test-samuel-123-pool1-6029f13c-b9zh   Ready    <none>   5m8s   v1.23.14-gke.1800

k get pods -A
NAMESPACE          NAME                                                         READY   STATUS    RESTARTS   AGE
cluster-registry   cluster-registry-controller-9557c4df6-2ftzm                  1/1     Running   0          35s
```

