### PR TITLE
Bump image and chart versions v0.2.7 -> v0.2.8

### DIFF
--- a/deploy/charts/cluster-registry/Chart.yaml
+++ b/deploy/charts/cluster-registry/Chart.yaml
@@ -9,5 +9,5 @@ maintainers:
 sources:
   - https://github.com/cisco-open/cluster-registry-controller
 
-version: 0.2.7
-appVersion: v0.2.7
+version: 0.2.8
+appVersion: v0.2.8

--- a/deploy/charts/cluster-registry/README.md
+++ b/deploy/charts/cluster-registry/README.md
@@ -41,7 +41,7 @@ Parameter | Description | Default
 `podSecurityContext` | Operator deployment pod security context (YAML) | runAsUser: `65534`, runAsGroup: `65534`
 `securityContext` | Operator deployment security context (YAML) | allowPrivilegeEscalation: `false`
 `image.repository` | Operator container image repository | `ghcr.io/cisco-open/cluster-registry-controller`
-`image.tag` | Operator container image tag | `v0.2.7`
+`image.tag` | Operator container image tag | `v0.2.8`
 `image.pullPolicy` | Operator container image pull policy | `IfNotPresent`
 `nodeselector` | Operator deployment node selector (YAML) | `{}`
 `affinity` | Operator deployment affinity (YAML) | `{}`

--- a/deploy/charts/cluster-registry/values.yaml
+++ b/deploy/charts/cluster-registry/values.yaml
@@ -26,7 +26,7 @@ securityContext:
       - ALL
 image:
   repository: ghcr.io/cisco-open/cluster-registry-controller
-  tag: v0.2.7
+  tag: v0.2.8
   pullPolicy: IfNotPresent
 
 nodeSelector: {}


### PR DESCRIPTION
Includes the helm chart support for OpenShift v4.11+