### PR TITLE
Openshift v4.10 support

### DIFF
--- a/deploy/charts/cluster-registry/values.yaml
+++ b/deploy/charts/cluster-registry/values.yaml
@@ -17,8 +17,7 @@ imagePullSecrets: []
 
 podSecurityContext:
   runAsNonRoot: true
-  seccompProfile:
-    type: RuntimeDefault
+
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:


### PR DESCRIPTION
## Description
Openshift v4.10 support
 
### Manual tests
K8s 1.24
```
k get nodes
NAME                                          STATUS   ROLES    AGE   VERSION
gke-smm-test-crc-samuel-pool1-1cb56090-2l9v   Ready    <none>   24h   v1.24.8-gke.2000
gke-smm-test-crc-samuel-pool1-1cb56090-khzq   Ready    <none>   24h   v1.24.8-gke.2000
gke-smm-test-crc-samuel-pool1-1cb56090-njh6   Ready    <none>   24h   v1.24.8-gke.2000

kgp -n cluster-registry
NAME                                          READY   STATUS    RESTARTS   AGE
cluster-registry-controller-c98988546-njg8r   1/1     Running   0          42s
```


RHOS 4.10
```
k get nodes -A
NAME                           STATUS   ROLES          AGE     VERSION
ip-10-0-140-234.ec2.internal   Ready    infra,worker   2d20h   v1.23.12+8a6bfe4
ip-10-0-152-244.ec2.internal   Ready    worker         2d20h   v1.23.12+8a6bfe4
ip-10-0-159-234.ec2.internal   Ready    master         2d20h   v1.23.12+8a6bfe4
ip-10-0-165-11.ec2.internal    Ready    master         2d20h   v1.23.12+8a6bfe4
ip-10-0-177-150.ec2.internal   Ready    worker         2d20h   v1.23.12+8a6bfe4
ip-10-0-189-85.ec2.internal    Ready    infra,worker   2d20h   v1.23.12+8a6bfe4
ip-10-0-207-95.ec2.internal    Ready    worker         2d20h   v1.23.12+8a6bfe4
ip-10-0-209-11.ec2.internal    Ready    master         2d20h   v1.23.12+8a6bfe4
ip-10-0-222-206.ec2.internal   Ready    infra,worker   2d20h   v1.23.12+8a6bfe4

k get pods -n cluster-registry
NAME                                           READY   STATUS    RESTARTS   AGE
cluster-registry-controller-78c77d884d-xlr5h   1/1     Running   0          23m
```

RHOS 4.11
```
k get nodes
NAME                           STATUS   ROLES          AGE    VERSION
ip-10-0-132-151.ec2.internal   Ready    infra,worker   3d4h   v1.24.6+5658434
ip-10-0-140-77.ec2.internal    Ready    worker         3d4h   v1.24.6+5658434
ip-10-0-158-35.ec2.internal    Ready    master         3d4h   v1.24.6+5658434
ip-10-0-159-227.ec2.internal   Ready    worker         3d4h   v1.24.6+5658434
ip-10-0-159-63.ec2.internal    Ready    worker         3d4h   v1.24.6+5658434
ip-10-0-160-205.ec2.internal   Ready    worker         3d4h   v1.24.6+5658434
ip-10-0-170-223.ec2.internal   Ready    worker         3d4h   v1.24.6+5658434
ip-10-0-180-115.ec2.internal   Ready    infra,worker   3d4h   v1.24.6+5658434
ip-10-0-183-15.ec2.internal    Ready    master         3d4h   v1.24.6+5658434
ip-10-0-187-200.ec2.internal   Ready    worker         3d4h   v1.24.6+5658434
ip-10-0-198-42.ec2.internal    Ready    worker         3d4h   v1.24.6+5658434
ip-10-0-205-221.ec2.internal   Ready    worker         3d4h   v1.24.6+5658434
ip-10-0-215-244.ec2.internal   Ready    infra,worker   3d4h   v1.24.6+5658434
ip-10-0-215-76.ec2.internal    Ready    master         3d4h   v1.24.6+5658434
ip-10-0-222-135.ec2.internal   Ready    worker         3d4h   v1.24.6+5658434

kgp -n cluster-registry
NAME                                          READY   STATUS    RESTARTS   AGE
cluster-registry-controller-b4d996889-n5gcz   1/1     Running   0          68s
```

