### PR TITLE
bump image and chart version to v0.2.10

### DIFF
--- a/deploy/charts/cluster-registry/Chart.yaml
+++ b/deploy/charts/cluster-registry/Chart.yaml
@@ -9,5 +9,5 @@ maintainers:
 sources:
   - https://github.com/cisco-open/cluster-registry-controller
 
-version: 0.2.9
-appVersion: v0.2.9
+version: 0.2.10
+appVersion: v0.2.10

--- a/deploy/charts/cluster-registry/README.md
+++ b/deploy/charts/cluster-registry/README.md
@@ -41,7 +41,7 @@ Parameter | Description | Default
 `podSecurityContext` | Operator deployment pod security context (YAML) | runAsUser: `65534`, runAsGroup: `65534`
 `securityContext` | Operator deployment security context (YAML) | allowPrivilegeEscalation: `false`
 `image.repository` | Operator container image repository | `ghcr.io/cisco-open/cluster-registry-controller`
-`image.tag` | Operator container image tag | `v0.2.9`
+`image.tag` | Operator container image tag | `v0.2.10`
 `image.pullPolicy` | Operator container image pull policy | `IfNotPresent`
 `nodeselector` | Operator deployment node selector (YAML) | `{}`
 `affinity` | Operator deployment affinity (YAML) | `{}`

--- a/deploy/charts/cluster-registry/values.yaml
+++ b/deploy/charts/cluster-registry/values.yaml
@@ -26,7 +26,7 @@ securityContext:
       - ALL
 image:
   repository: ghcr.io/cisco-open/cluster-registry-controller
-  tag: v0.2.9
+  tag: v0.2.10
   pullPolicy: IfNotPresent
 
 nodeSelector: {}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


Bump image and Chart version to 0.2.10.