### PR TITLE
Allow mutate target ns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN go mod download
 COPY ./ /workspace/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on make binary
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 GO111MODULE=on make binary
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN go mod download
 COPY ./ /workspace/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 GO111MODULE=on make binary
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on make binary
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -127,4 +127,3 @@ help:
 tidy: ## Execute go mod tidy
 	go mod tidy
 	go mod download all
-

--- a/controllers/sync_reconciler.go
+++ b/controllers/sync_reconciler.go
@@ -239,7 +239,7 @@ func (r *syncReconciler) reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	// check namespace existence
 	if obj.GetNamespace() != "" {
 		err := r.localClient.Get(ctx, types.NamespacedName{
-			Name: req.Namespace,
+			Name: obj.GetNamespace(),
 		}, &corev1.Namespace{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return ctrl.Result{}, err

--- a/controllers/sync_reconciler.go
+++ b/controllers/sync_reconciler.go
@@ -247,8 +247,9 @@ func (r *syncReconciler) reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 		if apierrors.IsNotFound(err) {
 			msg := "namespace does not exists locally"
-			r.localRecorder.Event(r.rule, corev1.EventTypeWarning, "ObjectNotReconciledMissingNamespace", fmt.Sprintf("could not reconcile (resource: %s): %s", req, msg))
-			log.Info(msg)
+			localResource := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
+			r.localRecorder.Event(r.rule, corev1.EventTypeWarning, "ObjectNotReconciledMissingNamespace", fmt.Sprintf("could not reconcile (resource: %s, localResource: %s): %s", req, localResource, msg))
+			log.Info(msg, "localResource", localResource.String())
 
 			return ctrl.Result{
 				RequeueAfter: time.Second * 30, //nolint:gomnd


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | maybe
| New feature?    | maybe
| API breaks?     | no
| Deprecations?   | no
| Related tickets | Hopefully fixes https://github.com/cisco-open/cluster-registry-controller/issues/50
| License         | Apache 2.0


### What's in this PR?
This change
- Mutates the namespace prior to checking the target namespace existence
- allows to track original namespace same way we track original name.

### Why?
Currently, if we mutate object's namespace, it gets created and immediately deleted. See more in linked issue


### Checklist
- [x] Implementation tested
- [ ] User guide and development docs updated (if needed)
