### PR TITLE
[K8s 1.25 support] Upgrade PodDisruptionBudget API version to v1

### DIFF
--- a/deploy/charts/cluster-registry/templates/poddistruptionbudget.yaml
+++ b/deploy/charts/cluster-registry/templates/poddistruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cluster-registry-controller.fullname" . }}


### PR DESCRIPTION
### Description
Upgrading PodDisruptionBudget API version to v1 to support K8s 1.25

Reference: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125
