### PR TITLE
Multi namespaces cache

### DIFF
--- a/api/v1alpha1/resourcesyncrule_types.go
+++ b/api/v1alpha1/resourcesyncrule_types.go
@@ -137,6 +137,32 @@ const (
 
 type ResourceSyncRuleStatus struct{}
 
+// GetRelatedNamespaces gathers namespaces from rule matchers
+// it returns an empty list if any of the matchers is without namespace filter
+// since it means every namespace is related
+func (s *ResourceSyncRule) GetRelatedNamespaces() []string {
+	namespaces := []string{}
+
+	_namespaces := map[string]struct{}{}
+
+	for _, rule := range s.Spec.Rules {
+		for _, match := range rule.Matches {
+			if len(match.Namespaces) == 0 {
+				return namespaces
+			}
+			for _, ns := range match.Namespaces {
+				_namespaces[ns] = struct{}{}
+			}
+		}
+	}
+
+	for ns := range _namespaces {
+		namespaces = append(namespaces, ns)
+	}
+
+	return namespaces
+}
+
 // +kubebuilder:object:root=true
 
 // ResourceSyncRule is the Schema for the resource sync rule API

--- a/controllers/cluster_reconciler.go
+++ b/controllers/cluster_reconciler.go
@@ -253,12 +253,12 @@ func (r *ClusterReconciler) getRemoteCluster(ctx context.Context, cluster *clust
 		return nil, errors.WrapIf(err, "could not create new cluster")
 	}
 
-	err = remoteCluster.AddController(clusters.NewManagedController("remote-cluster", NewRemoteClusterReconciler(cluster.Name, r.GetManager(), r.GetLogger()), r.GetLogger()))
+	err = remoteCluster.AddController(clusters.NewManagedController("remote-cluster", nil, NewRemoteClusterReconciler(cluster.Name, r.GetManager(), r.GetLogger()), r.GetLogger()))
 	if err != nil {
 		return nil, errors.WrapIf(err, "could not add managed controller")
 	}
 
-	err = remoteCluster.AddController(clusters.NewManagedController("remote-cluster-feature", NewClusterFeatureReconciler(cluster.Name, remoteCluster, r.GetLogger()), r.GetLogger()))
+	err = remoteCluster.AddController(clusters.NewManagedController("remote-cluster-feature", nil, NewClusterFeatureReconciler(cluster.Name, remoteCluster, r.GetLogger()), r.GetLogger()))
 	if err != nil {
 		return nil, errors.WrapIf(err, "could not add managed controller")
 	}

--- a/controllers/resource_sync_rule_reconciler.go
+++ b/controllers/resource_sync_rule_reconciler.go
@@ -229,7 +229,7 @@ func InitNewResourceSyncController(rule *clusterregistryv1alpha1.ResourceSyncRul
 	if err != nil {
 		return nil, errors.WithStackIf(err)
 	}
-	ctrl := clusters.NewManagedController(rule.Name, srec, log, clusters.WithRequiredClusterFeatures(requiredClusterFeatures...))
+	ctrl := clusters.NewManagedController(rule.Name, rule.GetRelatedNamespaces(), srec, log, clusters.WithRequiredClusterFeatures(requiredClusterFeatures...))
 
 	return ctrl, cluster.AddController(ctrl)
 }

--- a/controllers/sync_reconciler.go
+++ b/controllers/sync_reconciler.go
@@ -890,7 +890,17 @@ func (r *syncReconciler) createClient(config *rest.Config, cache cache.Cache) (c
 }
 
 func (r *syncReconciler) createAndStartCache() (cache.Cache, error) {
-	cche, err := cache.New(r.localMgr.GetConfig(), cache.Options{
+	cacheFunc := cache.New
+
+	relatedNamespaces := r.rule.GetRelatedNamespaces()
+	if len(relatedNamespaces) > 0 {
+		r.GetLogger().Info("create multi namespace cache", "namespaces", relatedNamespaces)
+		cacheFunc = cache.MultiNamespacedCacheBuilder(relatedNamespaces)
+	} else {
+		r.GetLogger().Info("create cache")
+	}
+
+	cche, err := cacheFunc(r.localMgr.GetConfig(), cache.Options{
 		Scheme: r.localMgr.GetScheme(),
 		Mapper: r.localMgr.GetRESTMapper(),
 	})

--- a/docs/resource-sync-rule.md
+++ b/docs/resource-sync-rule.md
@@ -1,0 +1,17 @@
+# Resource Sync Rule
+
+### Limit namespace cache
+In larger cluster with namespaces more than 30-40, it was observed that CR-controller watches/caches all the namespaces into the pod memory,
+which caused frequent OOMKilled issue while attaching peer clusters.
+
+To reduce memory caching by cluster-registry-controller we can use `namespaces` field in `ResourceSyncRule` to allow caching on selected
+namespaces.
+
+custom-resource
+`spec.rules.match.namespaces`
+```
+  namespaces:
+    items:
+      type: string
+    type: array
+```

--- a/pkg/clusters/cluster_test.go
+++ b/pkg/clusters/cluster_test.go
@@ -43,7 +43,7 @@ func TestClusterFeatures(t *testing.T) {
 	cf2 := clusters.NewClusterFeature("another-test-feature", "another-test-feature", nil)
 
 	r := clusters.NewManagedReconciler("test", logr.Discard())
-	c := clusters.NewManagedController("test", r, logr.Discard(), clusters.WithRequiredClusterFeatures(
+	c := clusters.NewManagedController("test", nil, r, logr.Discard(), clusters.WithRequiredClusterFeatures(
 		clusters.ClusterFeatureRequirement{
 			Name: "test-feature",
 			MatchLabels: map[string]string{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes memory issue in multicluster scenario
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Contains the changes required to limit namespace cache based on ResourceSyncRule `rules.match.namespaces`
* Adds the functionality to init cache for all namespaces if no namespaces list is provided in RSR or init cache with namespaces from RSR
* syncReconciler and managedController are updated to init cache from namespaces provided from RSR `rules.match.namespaces`

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
In larger cluster with namespaces more than 30-40, it was observed that CR-controller watches/caches all the namespaces into the mem, which caused frequent OOMKilled issue while attaching peer clusters.
This PR allows users to select namespaces to cache for their RSR, there-by reducing memory usage.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] User guide and development docs updated (if needed)
